### PR TITLE
Fixed bug when returning a single result

### DIFF
--- a/lib/pinboard/client.rb
+++ b/lib/pinboard/client.rb
@@ -15,7 +15,7 @@ module Pinboard
       options[:basic_auth] = @auth
 			options[:query] = params
       posts = self.class.get('/posts/all', options)['posts']['post']
-      posts = Array.new(1, posts) if !posts.kind_of?(Array)
+      posts = Array.new(1, posts) if !posts.nil? && !posts.kind_of?(Array)
       if !posts.nil?
         posts.map { |p| Post.new(Util.symbolize_keys(p)) }
       end


### PR DESCRIPTION
Fixed bug that happens when a single post is returned resulting in the posts variable not being an array. You can test the pre-fixed code by setting :results => 1
