### PR TITLE
Update documentation to use API token instead of username and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,13 @@ Examples
 I'm currently exploring two API interfaces:
 
 ```ruby
-    pinboard = Pinboard::Client.new(:username => 'foo', :password => 'bar')
+    pinboard = Pinboard::Client.new(:token => 'your_api_token')
     posts = pinboard.posts
 ```
+
+Your [API token](https://blog.pinboard.in/2012/07/api_authentication_tokens/) can be found on your
+[settings/password](https://pinboard.in/settings/password) page.
+
 or:
 
 ```ruby


### PR DESCRIPTION
Given the recent [blog post](https://blog.pinboard.in/2014/10/holy_war_on_sites_that_demand_pinboard_passwords/) on avoiding usernames and passwords to authenticate with Pinboard, I was
going to rewrite the `Client` class to accept api tokens.

After digging into the source, I noticed that this functionality was
already there, but the readme did not indicate this was possible.
