### PR TITLE
Updates HTTParty to avoid using URI methods deprecated in newer Ruby versions; control flow change in client.rb

### DIFF
--- a/lib/pinboard/client.rb
+++ b/lib/pinboard/client.rb
@@ -73,12 +73,15 @@ module Pinboard
     def suggest(url)
       options = create_params({url: url})
       suggested = self.class.get('/posts/suggest', options)['suggested']
-      popular = suggested['popular']
-      popular = [] if popular.nil?
-      popular = [popular] if popular.class != Array
 
-      recommended = suggested['recommended']
-      recommended = [] if recommended.nil?
+      if suggested.nil?
+        popular = []
+        recommended = []
+      else
+        popular = suggested['popular']
+        recommended = suggested['recommended']
+      end
+      popular = [popular] if popular.class != Array
       recommended = [recommended] if recommended.class != Array
 
       {:popular => popular, :recommended => recommended}

--- a/pinboard.gemspec
+++ b/pinboard.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'httparty', '= 0.17.3'
   s.name = 'pinboard'
-  s.version = '1.0.0'
-  s.date = '2016-01-05'
+  s.version = '1.0.1'
+  s.date = '2021-10-31'
   s.summary = "Ruby wrapper for the Pinboard API"
   s.description = "Ruby wrapper for the Pinboard API"
   s.authors = ["Ry Waker", "Jan-Erik Rediger"]

--- a/pinboard.gemspec
+++ b/pinboard.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rb-fsevent'
   s.add_development_dependency 'terminal-notifier-guard'
 
-  s.add_runtime_dependency 'httparty', '= 0.11.0'
+  s.add_runtime_dependency 'httparty', '= 0.17.3'
   s.name = 'pinboard'
   s.version = '1.0.0'
   s.date = '2016-01-05'


### PR DESCRIPTION
Be sure to take a look at the control flow change in `client.rb`. Before this change, the test for empty recommended/popular tags was erroring out. I think the new control flow still matches the spirit of the previous version, but as I said on Twitter, I'm no longer a real engineer, so I could have futzed it up. :)